### PR TITLE
Update endpoints to use inline fragments for account queries

### DIFF
--- a/fennel_invest_api/endpoints.py
+++ b/fennel_invest_api/endpoints.py
@@ -1,6 +1,4 @@
-# Endpoints for Fennel API
 import json
-
 
 class Endpoints:
     def __init__(self):
@@ -25,11 +23,27 @@ class Endpoints:
                 user {
                     id
                     accounts {
-                        name
-                        id
-                        created
-                        isPrimary
-                        status
+                        ... on Account {
+                            name
+                            id
+                            created
+                            isPrimary
+                            status
+                        }
+                        ... on RothIRA {
+                            name
+                            id
+                            created
+                            isPrimary
+                            status
+                        }
+                        ... on TraditionalIRA {
+                            name
+                            id
+                            created
+                            isPrimary
+                            status
+                        }
                     }
                 }
             }
@@ -40,21 +54,59 @@ class Endpoints:
         query = """
             query GetPortfolioSummary($accountId: String!) {
                 account(accountId: $accountId) {
-                    id
-                    portfolio {
-                        cash {
-                            balance {
-                                canTrade
-                                canWithdraw
-                                reservedBalance
-                                settledBalance
-                                tradeBalance
-                                tradeDecrease
-                                tradeIncrease
+                    ... on Account {
+                        id
+                        portfolio {
+                            cash {
+                                balance {
+                                    canTrade
+                                    canWithdraw
+                                    reservedBalance
+                                    settledBalance
+                                    tradeBalance
+                                    tradeDecrease
+                                    tradeIncrease
+                                }
+                                currency
                             }
-                            currency
+                            totalEquityValue
                         }
-                        totalEquityValue
+                    }
+                    ... on RothIRA {
+                        id
+                        portfolio {
+                            cash {
+                                balance {
+                                    canTrade
+                                    canWithdraw
+                                    reservedBalance
+                                    settledBalance
+                                    tradeBalance
+                                    tradeDecrease
+                                    tradeIncrease
+                                }
+                                currency
+                            }
+                            totalEquityValue
+                        }
+                    }
+                    ... on TraditionalIRA {
+                        id
+                        portfolio {
+                            cash {
+                                balance {
+                                    canTrade
+                                    canWithdraw
+                                    reservedBalance
+                                    settledBalance
+                                    tradeBalance
+                                    tradeDecrease
+                                    tradeIncrease
+                                }
+                                currency
+                            }
+                            totalEquityValue
+                        }
                     }
                 }
             }
@@ -65,20 +117,60 @@ class Endpoints:
         query = """
             query MinimumPortfolioData($accountId: String!) {
                 account(accountId: $accountId) {
-                    id
-                    portfolio {
-                        totalEquityValue
-                        bulbs {
-                            isin
-                            investment {
-                                marketValue
-                                ownedShares
+                    ... on Account {
+                        id
+                        portfolio {
+                            totalEquityValue
+                            bulbs {
+                                isin
+                                investment {
+                                    marketValue
+                                    ownedShares
+                                }
+                                security {
+                                    currentStockPrice
+                                    ticker
+                                    securityName
+                                    securityType
+                                }
                             }
-                            security {
-                                currentStockPrice
-                                ticker
-                                securityName
-                                securityType
+                        }
+                    }
+                    ... on RothIRA {
+                        id
+                        portfolio {
+                            totalEquityValue
+                            bulbs {
+                                isin
+                                investment {
+                                    marketValue
+                                    ownedShares
+                                }
+                                security {
+                                    currentStockPrice
+                                    ticker
+                                    securityName
+                                    securityType
+                                }
+                            }
+                        }
+                    }
+                    ... on TraditionalIRA {
+                        id
+                        portfolio {
+                            totalEquityValue
+                            bulbs {
+                                isin
+                                investment {
+                                    marketValue
+                                    ownedShares
+                                }
+                                security {
+                                    currentStockPrice
+                                    ticker
+                                    securityName
+                                    securityType
+                                }
                             }
                         }
                     }

--- a/fennel_invest_api/endpoints.py
+++ b/fennel_invest_api/endpoints.py
@@ -1,5 +1,6 @@
 import json
 
+
 class Endpoints:
     def __init__(self):
         self.accounts = "https://accounts.fennel.com"


### PR DESCRIPTION
Updates the GraphQL queries in the Endpoints class to match the current schema. 

Previously, the queries for retrieving account IDs, portfolio summaries, and stock holdings were querying fields directly on the FennelAccountTypes type. This change caused errors (“Cannot query field 'name' on type 'FennelAccountTypes'”) and returned null values.

Changes Made:

account_ids_query:
- Updated the query to use inline fragments on Account, RothIRA, and TraditionalIRA so that the fields (name, id, created, isPrimary, and status) are correctly returned.

portfolio_query:
- Modified the query to include inline fragments on Account, RothIRA, and TraditionalIRA to correctly retrieve portfolio data.

stock_holdings_query:
- Similarly updated this query with inline fragments for proper data retrieval.